### PR TITLE
comment out prevent default/allow touch screen scroll on mobile

### DIFF
--- a/main.js
+++ b/main.js
@@ -20,9 +20,9 @@ function openNav() {
         }
     })
 
-    mobileNav.addEventListener('touchmove', function(e) {   // Prevent scroll on touch devices (Needs tested)
-        e.preventDefault();
-    })
+    // mobileNav.addEventListener('touchmove', function(e) {   // Prevent scroll on touch devices
+    //     e.preventDefault();
+    // })
 }   
    
  btn.addEventListener('click', openNav);


### PR DESCRIPTION
Removed code that prevented scrolling in the hamburger menu on touch devices